### PR TITLE
fix(docker): use PORT environment variable for dynamic port configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ ENV PORT=8080
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -f http://localhost:8080/healthz || exit 1
+  CMD curl -f http://localhost:${PORT:-8080}/healthz || exit 1
 
 ENTRYPOINT ["/app/scripts/entrypoint.sh"]

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,7 +2,7 @@ services:
   openclaw:
     image: openclaw:local
     ports:
-      - "8080:8080"
+      - "${PORT:-8080}:${PORT:-8080}"
     environment:
       # Provider (at least one required)
       - OPENCODE_API_KEY=${OPENCODE_API_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   openclaw:
     image: coollabsio/openclaw:latest
     ports:
-      - "8080:8080"
+      - "${PORT:-8080}:${PORT:-8080}"
     environment:
       # Provider (at least one required)
       - ANTHROPIC_API_KEY=sk-ant-...

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -170,7 +170,7 @@ map "\$ocw_has_token:\$args" \$ocw_proxy_args {
 }
 
 server {
-    listen 8080 default_server;
+    listen ${PORT:-8080} default_server;
     server_name _;
 
     location = /healthz {


### PR DESCRIPTION
## Summary
- Replace hardcoded port `8080` with `${PORT:-8080}` environment variable across Docker and Nginx configurations
- Updates Dockerfile HEALTHCHECK to use the PORT environment variable
- Updates docker-compose files to support dynamic port mapping via PORT env var
- Updates Nginx server listen directive to use PORT environment variable

## Breaking Changes
None - PORT variable defaults to 8080, maintaining backward compatibility