### PR TITLE
chore(gateway): make bind mode configurable via OPENCLAW_GATEWAY_BIND

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,10 @@ AUTH_USERNAME=admin
 # Bearer token for gateway auth. Auto-generated and persisted if not set.
 OPENCLAW_GATEWAY_TOKEN=
 OPENCLAW_GATEWAY_PORT=18789
+# Gateway bind mode: loopback (default), lan (0.0.0.0), tailnet, auto, or custom.
+# Set to "lan" for direct LAN access on port 18789 (bypasses nginx auth).
+# Note: LAN access via nginx (port 8080) works regardless of this setting.
+# OPENCLAW_GATEWAY_BIND=loopback
 
 # ── Model selection ─────────────────────────────────────────────────────────
 # Override the default primary model. Format: provider/model-id

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ If a provider env var is removed, that provider section is cleaned from `opencla
 | Variable | Default | Description |
 |---|---|---|
 | `OPENCLAW_GATEWAY_TOKEN` | *(auto-generated)* | Bearer token for gateway auth. Auto-generated and persisted to `<STATE_DIR>/gateway.token` if not set. |
-| `OPENCLAW_GATEWAY_PORT` | `18789` | Internal port the gateway binds to (loopback). |
+| `OPENCLAW_GATEWAY_PORT` | `18789` | Internal port the gateway binds to. |
+| `OPENCLAW_GATEWAY_BIND` | `loopback` | Gateway bind mode. `loopback` = 127.0.0.1 only (nginx proxies LAN traffic). `lan` = 0.0.0.0 (direct access, bypasses nginx auth). Also: `tailnet`, `auto`, `custom`. |
 | `OPENCLAW_STATE_DIR` | `/data/.openclaw` | Persistent state directory. Mount a volume here. |
 | `OPENCLAW_WORKSPACE_DIR` | `/data/workspace` | Workspace directory for openclaw projects. |
 | `OPENCLAW_CONFIG_PATH` | `<STATE_DIR>/openclaw.json` | Override path to the config file. |

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -276,7 +276,7 @@ GATEWAY_ARGS=(
   --port "$GATEWAY_PORT"
   --verbose
   --allow-unconfigured
-  --bind loopback
+  --bind "${OPENCLAW_GATEWAY_BIND:-loopback}"
 )
 
 GATEWAY_ARGS+=(--token "$GATEWAY_TOKEN")


### PR DESCRIPTION
## Summary

- Add `OPENCLAW_GATEWAY_BIND` environment variable to configure gateway bind mode
- Defaults to `loopback` to maintain current behavior
- Supports modes: `loopback` (127.0.0.1 only), `lan` (0.0.0.0 direct access), `tailnet`, `auto`, and `custom`
- Update documentation with bind mode explanation and use cases

## Changes

- **entrypoint.sh**: Replace hardcoded `--bind loopback` with configurable `${OPENCLAW_GATEWAY_BIND:-loopback}`
- **.env.example**: Add commented example with explanation of bind modes
- **README.md**: Document new variable and its options