### PR TITLE
fix(minimax): correct API compatibility and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Triggers: `schedule: '0 */6 * * *'` + `workflow_dispatch` (version, force_rebuil
 | `VENICE_API_KEY` | Venice AI API key (OpenAI-compatible). Configures Llama 3.3 70B. |
 | `MOONSHOT_API_KEY` | Moonshot API key (OpenAI-compatible). Configures Kimi K2.5. |
 | `KIMI_API_KEY` | Kimi Coding API key (Anthropic-compatible). Configures K2P5. |
-| `MINIMAX_API_KEY` | MiniMax API key (OpenAI-compatible). Configures MiniMax M2.1. |
+| `MINIMAX_API_KEY` | MiniMax API key (Anthropic-compatible). Configures MiniMax M2.1. |
 | `ZAI_API_KEY` | ZAI API key. Configures GLM models. |
 | `AI_GATEWAY_API_KEY` | Vercel AI Gateway API key. |
 | `OPENCODE_API_KEY` | OpenCode API key. Also accepted as `OPENCODE_ZEN_API_KEY`. |

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -182,16 +182,16 @@ if (process.env.VENICE_API_KEY) {
   removeProvider("venice", "Venice AI", "VENICE_API_KEY");
 }
 
-// MiniMax (OpenAI-compatible)
+// MiniMax (Anthropic-compatible)
 if (process.env.MINIMAX_API_KEY) {
   console.log("[configure] configuring MiniMax provider");
   ensure(config, "models", "providers");
   config.models.providers.minimax = {
-    api: "openai-completions",
+    api: "anthropic-messages",
     apiKey: process.env.MINIMAX_API_KEY,
-    baseUrl: "https://api.minimax.chat/v1",
+    baseUrl: "https://api.minimax.io/anthropic",
     models: [
-      { id: "MiniMax-M2.1", name: "MiniMax M2.1", contextWindow: 192000 },
+      { id: "MiniMax-M2.1", name: "MiniMax M2.1", contextWindow: 200000 },
     ],
   };
 } else {


### PR DESCRIPTION
## Summary

- Fixed MiniMax provider configuration from OpenAI-compatible to Anthropic-compatible
- Corrected API endpoint from `https://api.minimax.chat/v1` to `https://api.minimax.io/anthropic`
- Updated API type from `openai-completions` to `anthropic-messages`
- Fixed context window from 192000 to 200000 tokens
- Updated documentation to reflect correct API compatibility

## Breaking Changes

MiniMax provider configuration has changed. Users with existing `MINIMAX_API_KEY` environment variable set will need to ensure their setup matches the corrected Anthropic-compatible configuration.

---

Closes #9