### PR TITLE
fix: parse BEDROCK_PROVIDER_FILTER as array instead of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ If a provider env var is removed, that provider section is cleaned from `opencla
 | `AWS_SECRET_ACCESS_KEY` | | AWS secret key. |
 | `AWS_REGION` | `us-east-1` | AWS region for Bedrock runtime endpoint. |
 | `AWS_SESSION_TOKEN` | | Optional session token for temporary credentials. |
-| `BEDROCK_PROVIDER_FILTER` | `anthropic` | Filter Bedrock model discovery by provider. |
+| `BEDROCK_PROVIDER_FILTER` | `["anthropic"]` | Filter Bedrock model discovery by provider (JSON array or comma-separated string). |
 
 ### Ollama (local models, no API key needed)
 

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -276,10 +276,20 @@ if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
     ],
   };
   ensure(config, "models");
+  // providerFilter must be an array; env var may be JSON array, CSV, or plain string
+  let providerFilter = ["anthropic"];
+  if (process.env.BEDROCK_PROVIDER_FILTER) {
+    try {
+      const parsed = JSON.parse(process.env.BEDROCK_PROVIDER_FILTER);
+      providerFilter = Array.isArray(parsed) ? parsed : [parsed];
+    } catch {
+      providerFilter = process.env.BEDROCK_PROVIDER_FILTER.split(",").map(s => s.trim());
+    }
+  }
   config.models.bedrockDiscovery = {
     enabled: true,
     region,
-    providerFilter: process.env.BEDROCK_PROVIDER_FILTER || "anthropic",
+    providerFilter,
     refreshInterval: 3600,
   };
 } else if (!hasCustomConfig && config.models?.providers?.["amazon-bedrock"]) {


### PR DESCRIPTION
## Problem

When deploying with `BEDROCK_PROVIDER_FILTER` env var (or using the default value), `configure.js` writes it directly as a string to `openclaw.json`, but the config schema expects an **array**, causing startup failure:

```
models.bedrockDiscovery.providerFilter: Invalid input: expected array, received string
```

## Fix

Parse the env var properly before assigning to `providerFilter`:
- JSON array (`["anthropic"]`) → parsed as-is
- Comma-separated string (`anthropic,meta`) → split into array
- Plain string (`anthropic`) → wrapped in array

Default value changed from `"anthropic"` to `["anthropic"]`.