### PR TITLE
chore(docker): use environment variables for auth credentials

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -8,9 +8,9 @@ services:
       - OPENCODE_API_KEY=${OPENCODE_API_KEY}
       - OPENCLAW_PRIMARY_MODEL=opencode/kimi-k2.5
       # Auth
-      - AUTH_USERNAME=whatever
-      - AUTH_PASSWORD=secret
-      - OPENCLAW_GATEWAY_TOKEN=local-dev-token
+      - AUTH_USERNAME=${AUTH_USERNAME:-admin}
+      - AUTH_PASSWORD=${AUTH_PASSWORD}
+      - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
       # Browser sidecar
       - BROWSER_CDP_URL=http://browser:9223
       - BROWSER_DEFAULT_PROFILE=openclaw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,9 @@ services:
       - OPENCODE_API_KEY=${OPENCODE_API_KEY}
       - OPENCLAW_PRIMARY_MODEL=opencode/kimi-k2.5
       # Auth
-      - AUTH_USERNAME=whatever
-      - AUTH_PASSWORD=changeme
-      - OPENCLAW_GATEWAY_TOKEN=my-secret-token
+      - AUTH_USERNAME=${AUTH_USERNAME:-admin}
+      - AUTH_PASSWORD=${AUTH_PASSWORD}
+      - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
       # Browser sidecar
       - BROWSER_CDP_URL=http://browser:9223
       - BROWSER_DEFAULT_PROFILE=openclaw


### PR DESCRIPTION
## Summary

- Replace hardcoded auth credentials with environment variable overrides in both `docker-compose.yml` and `docker-compose.local.yml`
- Use `${AUTH_USERNAME:-admin}` with a default fallback for local development
- Remove hardcoded values: `whatever`, `changeme`, `secret`, `local-dev-token`, and `my-secret-token`
- Align credential management with existing `OPENCODE_API_KEY` pattern

## Benefits

- Keeps secrets out of version control
- Enables safer, more flexible deployments across environments
- Supports local development with sensible defaults while requiring explicit values in production

---

Closes #11