### PR TITLE
fix(entrypoint): improve custom init script handling and permissions

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -63,9 +63,15 @@ export HOME="${STATE_DIR%/.openclaw}"
 
 # ── Run custom init script (if provided) ─────────────────────────────────────
 INIT_SCRIPT="${OPENCLAW_DOCKER_INIT_SCRIPT:-}"
-if [ -n "$INIT_SCRIPT" ] && [ -f "$INIT_SCRIPT" ] && [ -x "$INIT_SCRIPT" ]; then
-  echo "[entrypoint] running init script: $INIT_SCRIPT"
-  "$INIT_SCRIPT" || echo "[entrypoint] WARNING: init script exited with code $?"
+if [ -n "$INIT_SCRIPT" ]; then
+  if [ ! -f "$INIT_SCRIPT" ]; then
+    echo "[entrypoint] WARNING: init script not found: $INIT_SCRIPT"
+  else
+    # Auto-make executable — volume mounts often lose +x
+    chmod +x "$INIT_SCRIPT" 2>/dev/null || true
+    echo "[entrypoint] running init script: $INIT_SCRIPT"
+    "$INIT_SCRIPT" || echo "[entrypoint] WARNING: init script exited with code $?"
+  fi
 fi
 
 # ── Configure openclaw from env vars ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Improved error handling for custom init scripts by checking if the file exists and providing a warning message when it doesn't
- Automatically set executable permissions on init scripts with `chmod +x` to work around permission loss from Docker volume mounts
- Simplified the condition logic for better readability and robustness
- Made the script more resilient to common Docker volume permission issues

## Breaking Changes

None