### PR TITLE
chore(ci): add force rebuild option to docker image workflow

### DIFF
--- a/.github/workflows/rebuild-versions.yml
+++ b/.github/workflows/rebuild-versions.yml
@@ -11,6 +11,10 @@ on:
         description: 'Or rebuild a specific version (e.g., 2026.1.29)'
         type: string
         required: false
+      force_rebuild:
+        description: 'Force rebuild base images even if they already exist'
+        type: boolean
+        default: false
 
 env:
   GITHUB_REGISTRY: ghcr.io
@@ -56,6 +60,14 @@ jobs:
         id: check
         run: |
           VERSIONS='${{ needs.get-versions.outputs.versions }}'
+          FORCE_REBUILD="${{ github.event.inputs.force_rebuild }}"
+
+          if [ "$FORCE_REBUILD" = "true" ]; then
+            echo "Force rebuild enabled, marking all base images as missing"
+            echo "missing_versions=$VERSIONS" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           MISSING="[]"
 
           for VERSION in $(echo "$VERSIONS" | jq -r '.[]'); do


### PR DESCRIPTION
## Summary

- Add `force_rebuild` boolean input parameter to the rebuild-versions workflow
- Skip existing image checks when force rebuild is enabled
- Allow manual triggering of complete base image rebuilds regardless of cache state

## Changes

- Added `force_rebuild` workflow input with default value of `false`
- Implemented early exit logic in the version checking step to mark all versions as missing when force rebuild is enabled
- Enables users to bypass the existing image check and force a complete rebuild of all base images through the GitHub Actions workflow dispatch UI