### PR TITLE
Fix: Add explicit network for Dokploy deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       # Hooks (optional)
       # - HOOKS_ENABLED=true
       # - HOOKS_TOKEN=my-hook-secret
+    networks:
+        - openclaw-net
     volumes:
       - openclaw-data:/data
       # Optional: custom JSON config for complex settings (groups, plugins, etc.)
@@ -35,11 +37,17 @@ services:
       - PGID=1000
       - TZ=Etc/UTC
       - CHROME_CLI=--remote-debugging-port=9222
+    networks:
+        - openclaw-net
     volumes:
       - browser-data:/config
     shm_size: 2g
     restart: unless-stopped
 
+networks:
+    openclaw-net:
+      driver: bridge
+      
 volumes:
   openclaw-data:
   browser-data:


### PR DESCRIPTION
  ## Problem
  When deploying with Dokploy, nginx fails to start with error:
  [emerg] host not found in upstream "browser"

  ## Root Cause
  Dokploy's network isolation prevents automatic service discovery between containers.

  ## Solution
  Add explicit `openclaw-net` bridge network to both services.

  ## Testing
  - [x] Deploy on Dokploy
  - [x] Verify browser service resolves correctly
  - [x] Confirm openclaw can connect to browser CDP endpoint