### PR TITLE
fix(configure): remove invalid channels.whatsapp.enabled key

### DIFF
--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -531,7 +531,6 @@ if (process.env.WHATSAPP_ENABLED === "true" || process.env.WHATSAPP_ENABLED === 
   console.log("[configure] configuring WhatsApp channel (from env)");
   ensure(config, "channels");
   const wa = config.channels.whatsapp = {}; // full overwrite — env vars are authoritative
-  wa.enabled = true;
 
   // strings
   if (process.env.WHATSAPP_DM_POLICY)        wa.dmPolicy = process.env.WHATSAPP_DM_POLICY;


### PR DESCRIPTION
## Summary
Removes the `wa.enabled = true` assignment from WhatsApp env mapping in `scripts/configure.js`.

`channels.whatsapp.enabled` is not a valid config key in current schema, and its presence leads to invalid-config errors (`Unrecognized key: "enabled"`) during startup.

## Why
WhatsApp activation is already gated by `WHATSAPP_ENABLED`; no `enabled` field needs to be written into `channels.whatsapp`.

## Fix
- Delete the line that writes `wa.enabled = true`.

Fixes #35
