### PR TITLE
fix: pass through webhook Authorization header instead of overwriting

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -116,7 +116,7 @@ HOOKS_LOCATION_BLOCK=""
 if [ -n "$HOOKS_PATH" ]; then
   HOOKS_LOCATION_BLOCK="location ${HOOKS_PATH} {
         proxy_pass http://127.0.0.1:${GATEWAY_PORT};
-        proxy_set_header Authorization \"Bearer ${GATEWAY_TOKEN}\";
+        proxy_set_header Authorization \\\$http_authorization;
 
         proxy_set_header Host \\\$host;
         proxy_set_header X-Real-IP \\\$remote_addr;


### PR DESCRIPTION
## Summary

The nginx proxy was overwriting the `Authorization` header for `/hooks` requests with the gateway token, causing 401 errors when `hooks.token` differs from `GATEWAY_TOKEN`.

## Change

Pass through the original `Authorization` header (`$http_authorization`) instead of replacing it, so webhooks can authenticate with their own token.

```diff
- proxy_set_header Authorization "Bearer ${GATEWAY_TOKEN}";
+ proxy_set_header Authorization $http_authorization;
```

## Testing

1. Configure a webhook with a separate `hooks.token`
2. Send a request with `Authorization: Bearer <hooks_token>`
3. Verify it passes through and authenticates correctly

Fixes #37