### PR TITLE
fix: install OpenClaw deps from frozen lockfile

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -21,6 +21,9 @@ WORKDIR /openclaw
 ARG OPENCLAW_GIT_REF=main
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
+RUN pnpm install --frozen-lockfile
+RUN pnpm ui:install
+
 # Patch: relax version requirements for packages using workspace protocol.
 RUN set -eux; \
   find ./extensions -name 'package.json' -type f | while read -r f; do \
@@ -28,10 +31,9 @@ RUN set -eux; \
     sed -i -E 's/"openclaw"[[:space:]]*:[[:space:]]*"workspace:[^"]+"/"openclaw": "*"/g' "$f"; \
   done
 
-RUN pnpm install --no-frozen-lockfile
 RUN pnpm build
 ENV OPENCLAW_PREFER_PNPM=1
-RUN pnpm ui:install && pnpm ui:build
+RUN pnpm ui:build
 
 
 # Runtime image


### PR DESCRIPTION
## Summary

This changes the base image build so dependency installation happens from the upstream OpenClaw release lockfile before the Docker-specific package metadata patch is applied.

The Dockerfile still relaxes bundled extension `openclaw` workspace/peer references before the build output is copied into the runtime image, but it no longer runs `pnpm install --no-frozen-lockfile` after mutating upstream `package.json` files.

## Root Cause

The current Dockerfile patches extension manifests first, replacing `openclaw` references like `workspace:*` and `>=2026.x.y` with `*`, then runs `pnpm install --no-frozen-lockfile`.

That makes pnpm resolve dependencies fresh instead of trusting the OpenClaw release lockfile. OpenClaw has `minimumReleaseAge: 2880` in `pnpm-workspace.yaml`, so scheduled Docker builds can fail whenever a release includes a dependency published less than 48 hours ago.

This explains the stale `latest` behavior reported in #63: a release can fail during the transient dependency-age window, then the hourly workflow moves on once a newer upstream release exists, leaving the skipped version and `latest` tag behind. The same pattern is happening again with `v2026.5.2`.

## Recent Reproduction

For `v2026.5.2`, the base image build failed at `pnpm install --no-frozen-lockfile` with:

```text
ERR_PNPM_NO_MATURE_MATCHING_VERSION
Version 3.1041.0 of @aws-sdk/client-bedrock does not meet the minimumReleaseAge constraint
```

After moving the root install before the metadata patch, `pnpm ui:install` still performed another install and hit the same age gate on `typebox@1.1.37`, so this PR also moves `ui:install` before the patch. The actual build steps remain after the patch.

## Why This Fix

- Uses `pnpm install --frozen-lockfile`, so Docker builds install exactly what the upstream release committed.
- Preserves OpenClaw's `minimumReleaseAge` supply-chain guard instead of disabling it or adding broad excludes.
- Keeps the existing Docker metadata relaxation before `pnpm build` / `pnpm ui:build`, so the runtime tree still gets the relaxed bundled extension package metadata.
- Avoids transient CI failures caused only by package publish timing.

## Verification

I reproduced the current `v2026.5.2` failure locally before the change, then verified the patched Dockerfile with:

```bash
docker build \
  -f Dockerfile.base \
  --build-arg OPENCLAW_GIT_REF=v2026.5.2 \
  --target openclaw-build \
  --progress=plain \
  --output type=cacheonly \
  .
```

The build passed through `pnpm install --frozen-lockfile`, `pnpm ui:install`, `pnpm build`, and `pnpm ui:build` without hitting `ERR_PNPM_NO_MATURE_MATCHING_VERSION`.

Fixes #63.