### PR TITLE
fix: prevent pnpm auto-install during Docker build

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -31,6 +31,9 @@ RUN set -eux; \
     sed -i -E 's/"openclaw"[[:space:]]*:[[:space:]]*"workspace:[^"]+"/"openclaw": "*"/g' "$f"; \
   done
 
+# The metadata patch intentionally makes node_modules look stale to pnpm 11.
+# Dependencies were already installed from the frozen upstream lockfile.
+ENV pnpm_config_verify_deps_before_run=false
 RUN pnpm build
 ENV OPENCLAW_PREFER_PNPM=1
 RUN pnpm ui:build


### PR DESCRIPTION
## Summary

Fixes the scheduled Docker image build for OpenClaw releases that use pnpm 11 by preventing `pnpm build` from auto-running a second dependency install after the Docker metadata patch.

The Dockerfile still installs dependencies from the upstream release lockfile with `pnpm install --frozen-lockfile`; this only disables pnpm's pre-script dependency freshness auto-install for the later build commands.

## Root Cause

This is similar to #63, but one layer deeper.

PR #69 fixed the explicit post-patch install by moving dependency installation before the Dockerfile relaxes bundled extension `openclaw` workspace/peer references.

The new failure happens because OpenClaw `v2026.5.20` uses `pnpm@11.1.0`. pnpm 11 defaults `verifyDepsBeforeRun` to `install`, so when `pnpm build` runs after the metadata patch, pnpm sees `node_modules` as stale and implicitly runs another `pnpm install`.

That implicit install re-enters dependency resolution and hits OpenClaw's `minimumReleaseAge: 2880` guard:

```text
[ERR_PNPM_NO_MATURE_MATCHING_VERSION] Version 2.5.0 of @google/genai does not meet the minimumReleaseAge constraint
```

Because the base image build fails, the versioned image and final `latest` manifest are never pushed, leaving `latest` on the previous successful OpenClaw image.

## Why This Fix

- Keeps dependency installation pinned to the upstream release lockfile via `pnpm install --frozen-lockfile`.
- Preserves OpenClaw's `minimumReleaseAge` protection during actual dependency installation.
- Prevents pnpm 11 from doing an unintended second install after the Docker-only package metadata patch.
- Keeps the existing package metadata relaxation before `pnpm build` / `pnpm ui:build`.

## Verification

I reproduced the failing path against `v2026.5.20` from the failed scheduled build.

With this change, the Docker build passed the previous failure point: `pnpm build` started the OpenClaw build directly instead of auto-running `pnpm install` and failing on `@google/genai`.

My local Docker build later exited during upstream `tsdown` with SIGTERM, which appears unrelated to the `minimumReleaseAge` failure and likely due to local builder resources. `git diff --check` passes.

Fixes #73.