### PR TITLE
fix: normalize Coolify FQDN for allowed origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ Configure Cross-Origin Resource Sharing for the Control UI. Required when access
 |---|---|
 | `OPENCLAW_ALLOWED_ORIGINS` | Comma-separated list or JSON array of allowed origins. Example: `http://localhost:5173,https://app.example.com` or `["http://localhost:5173"]`. |
 
+On Coolify, `COOLIFY_FQDN` is added automatically. If Coolify supplies a bare
+hostname, it is normalized to an HTTPS origin (for example,
+`app.example.com` becomes `https://app.example.com`). Explicit `http://` and
+`https://` schemes are preserved.
+
 ```bash
 # Allow specific origins
 OPENCLAW_ALLOWED_ORIGINS=http://localhost:5173,https://app.example.com
@@ -407,8 +412,8 @@ environment:
 
 | Variable | Description |
 |---|---|
-| `COOLIFY_FQDN` | Public FQDN assigned by Coolify. |
-| `COOLIFY_URL` | Coolify dashboard URL. |
+| `COOLIFY_FQDN` | Public FQDN assigned by Coolify. Bare hostnames are normalized to `https://` for the Control UI allowed origins. |
+| `COOLIFY_URL` | Coolify URL used as the allowed-origin fallback when `COOLIFY_FQDN` is unavailable. Bare hostnames are normalized to `https://`. |
 | `COOLIFY_BRANCH` | Git branch deployed. |
 
 ## Custom JSON config (Docker mount)

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -14,6 +14,7 @@ const {
   coerceType,
   parseArrayValue,
   parseAllowedOrigins,
+  normalizeCoolifyOrigin,
 } = require('./utils');
 
 const STATE_DIR = (process.env.OPENCLAW_STATE_DIR || "/data/.openclaw").replace(/\/+$/, "");
@@ -690,10 +691,10 @@ function applyAllowedOrigins() {
   // Automatically inject Coolify's FQDN if we are running in a Coolify environment
   const rawFqdn = process.env.COOLIFY_FQDN || process.env.COOLIFY_URL;
   if (rawFqdn) {
-    const cleanFqdn = rawFqdn.replace(/\/+$/, "");
-    if (cleanFqdn && !origins.includes(cleanFqdn)) {
-      origins.push(cleanFqdn);
-      console.log(`[configure] injected Coolify origin: ${cleanFqdn}`);
+    const coolifyOrigin = normalizeCoolifyOrigin(rawFqdn);
+    if (coolifyOrigin && !origins.includes(coolifyOrigin)) {
+      origins.push(coolifyOrigin);
+      console.log(`[configure] injected Coolify origin: ${coolifyOrigin}`);
     }
   }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -80,6 +80,22 @@ function parseAllowedOrigins(rawValue) {
   return parseArrayValue(trimmed);
 }
 
+/**
+ * Converts a Coolify-provided hostname or URL into a browser origin.
+ * Coolify may expose COOLIFY_FQDN without a scheme, while OpenClaw compares
+ * allowed origins against the browser's full Origin header.
+ * @param {string} rawValue - The COOLIFY_FQDN or COOLIFY_URL value
+ * @returns {string} - A normalized HTTP(S) origin without trailing slashes
+ */
+function normalizeCoolifyOrigin(rawValue) {
+  const trimmed = rawValue.trim().replace(/\/+$/, '');
+  if (!trimmed) {
+    return '';
+  }
+
+  return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
 module.exports = {
   REGEX,
   ENV_VAR,
@@ -87,4 +103,5 @@ module.exports = {
   coerceType,
   parseArrayValue,
   parseAllowedOrigins,
+  normalizeCoolifyOrigin,
 };

--- a/scripts/utils.test.js
+++ b/scripts/utils.test.js
@@ -11,6 +11,7 @@ const {
   coerceType,
   parseArrayValue,
   parseAllowedOrigins,
+  normalizeCoolifyOrigin,
 } = require('./utils');
 
 let passed = 0;
@@ -143,6 +144,41 @@ throws(
 throws(
   () => parseAllowedOrigins('['),
   'bare bracket throws'
+);
+
+// ── normalizeCoolifyOrigin ──────────────────────────────────────────────────
+
+console.log('normalizeCoolifyOrigin');
+
+eq(
+  normalizeCoolifyOrigin('app.example.com'),
+  'https://app.example.com',
+  'bare hostname defaults to https'
+);
+eq(
+  normalizeCoolifyOrigin('app.example.com/'),
+  'https://app.example.com',
+  'bare hostname drops trailing slash'
+);
+eq(
+  normalizeCoolifyOrigin(' https://app.example.com/ '),
+  'https://app.example.com',
+  'https origin is preserved and trimmed'
+);
+eq(
+  normalizeCoolifyOrigin('http://localhost:8080/'),
+  'http://localhost:8080',
+  'explicit http origin is preserved'
+);
+eq(
+  normalizeCoolifyOrigin(''),
+  '',
+  'empty value stays empty'
+);
+eq(
+  normalizeCoolifyOrigin(' / '),
+  '',
+  'slash-only value becomes empty'
 );
 
 // ── REGEX patterns ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #72

## What changed

- Normalize the automatically injected `COOLIFY_FQDN` / `COOLIFY_URL` value before adding it to `gateway.controlUi.allowedOrigins`.
- Default a bare hostname to `https://`, remove trailing slashes, and preserve explicit `http://` or `https://` schemes.
- Add regression coverage for bare hostnames, explicit schemes, whitespace, and empty values.
- Document the Coolify-specific normalization behavior.

## Root cause

Coolify can provide `COOLIFY_FQDN` as a bare hostname such as `app.example.com`. The browser sends the full origin `https://app.example.com`, but the template previously added only the bare hostname to OpenClaw's allowlist. Because origin checks are exact, the Control UI WebSocket was rejected with `origin not allowed`.

This change only normalizes the template's automatic Coolify origin. User-provided `OPENCLAW_ALLOWED_ORIGINS`, Gateway authentication, and device pairing behavior are unchanged.

## Validation

- `node scripts/utils.test.js` — 87 passed, 0 failed
- `node --check scripts/configure.js`
- `node --check scripts/utils.js`
- Disposable `configure.js` run with `COOLIFY_FQDN=app.example.com` produced `allowedOrigins: ["https://app.example.com"]`
- Disposable run with the same explicit `OPENCLAW_ALLOWED_ORIGINS` confirmed the normalized origin is not duplicated
- `git diff --check`
