### PR TITLE
Refresh MiniMax provider for M3 and M2.7 with configurable base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,6 +189,7 @@ AI_GATEWAY_BASE_URL=
 ANTHROPIC_BASE_URL=
 MOONSHOT_BASE_URL=
 KIMI_BASE_URL=
+MINIMAX_BASE_URL=
 
 # ── Extra system packages (optional) ──────────────────────────────────────────
 # Space-separated list of apt packages to install at container startup.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Triggers: `schedule: '0 */6 * * *'` + `workflow_dispatch` (version, force_rebuil
 | `VENICE_API_KEY` | Venice AI API key (OpenAI-compatible). Configures Llama 3.3 70B. |
 | `MOONSHOT_API_KEY` | Moonshot API key (OpenAI-compatible). Configures Kimi K2.5. |
 | `KIMI_API_KEY` | Kimi Coding API key (Anthropic-compatible). Configures K2P5. |
-| `MINIMAX_API_KEY` | MiniMax API key (Anthropic-compatible). Configures MiniMax M2.1. |
+| `MINIMAX_API_KEY` | MiniMax API key (Anthropic-compatible). Configures MiniMax M3 and M2.7. |
 | `ZAI_API_KEY` | ZAI API key. Configures GLM models. |
 | `AI_GATEWAY_API_KEY` | Vercel AI Gateway API key. |
 | `OPENCODE_API_KEY` | OpenCode API key. Also accepted as `OPENCODE_ZEN_API_KEY`. |
@@ -331,6 +331,7 @@ If a channel env var is removed, that channel is cleaned from config on next sta
 | `ANTHROPIC_BASE_URL` | Override Anthropic API base URL specifically. |
 | `MOONSHOT_BASE_URL` | Override Moonshot API base URL. Default: `https://api.moonshot.ai/v1`. |
 | `KIMI_BASE_URL` | Override Kimi Coding API base URL. Default: `https://api.moonshot.ai/anthropic`. |
+| `MINIMAX_BASE_URL` | Override MiniMax API base URL. Default: `https://api.minimax.io/anthropic` (global). Set to `https://api.minimaxi.com/anthropic` for the China endpoint. |
 
 ### Extra system packages (optional)
 

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -199,15 +199,18 @@ if (process.env.VENICE_API_KEY) {
 }
 
 // MiniMax (Anthropic-compatible)
+// Global endpoint: https://api.minimax.io/anthropic
+// China endpoint:  https://api.minimaxi.com/anthropic (override with MINIMAX_BASE_URL)
 if (process.env.MINIMAX_API_KEY) {
   console.log("[configure] configuring MiniMax provider");
   ensure(config, "models", "providers");
   config.models.providers.minimax = {
     api: "anthropic-messages",
     apiKey: process.env.MINIMAX_API_KEY,
-    baseUrl: "https://api.minimax.io/anthropic",
+    baseUrl: (process.env.MINIMAX_BASE_URL || "https://api.minimax.io/anthropic").replace(/\/+$/, ""),
     models: [
-      { id: "MiniMax-M2.1", name: "MiniMax M2.1", contextWindow: 200000 },
+      { id: "MiniMax-M3", name: "MiniMax M3", contextWindow: 1000000 },
+      { id: "MiniMax-M2.7", name: "MiniMax M2.7", contextWindow: 204800 },
     ],
   };
 } else {
@@ -346,7 +349,7 @@ const primaryCandidates = [
   [process.env.VENICE_API_KEY,         "venice/llama-3.3-70b"],
   [process.env.MOONSHOT_API_KEY,       "moonshot/kimi-k2.5"],
   [process.env.KIMI_API_KEY,           "kimi-coding/k2p5"],
-  [process.env.MINIMAX_API_KEY,        "minimax/MiniMax-M2.1"],
+  [process.env.MINIMAX_API_KEY,        "minimax/MiniMax-M3"],
   [process.env.SYNTHETIC_API_KEY,      "synthetic/hf:MiniMaxAI/MiniMax-M2.1"],
   [process.env.ZAI_API_KEY,            "zai/glm-4.7"],
   [process.env.AI_GATEWAY_API_KEY,     "vercel-ai-gateway/anthropic/claude-opus-4.5"],


### PR DESCRIPTION
Reason: Refresh the stale MiniMax provider to current MiniMax-M3 and MiniMax-M2.7 models with a configurable global/China Anthropic-compatible base URL.

## Changes

- Replace the single `MiniMax-M2.1` (200,000-token context) model with the current models:
  - `MiniMax-M3` — 1,000,000-token context window
  - `MiniMax-M2.7` — 204,800-token context window
- Make the Anthropic-compatible base URL configurable via `MINIMAX_BASE_URL`:
  - Default (global): `https://api.minimax.io/anthropic`
  - China endpoint: `https://api.minimaxi.com/anthropic`
- Update the auto-selected primary model candidate from `minimax/MiniMax-M2.1` to `minimax/MiniMax-M3`.
- Document `MINIMAX_BASE_URL` in `.env.example` and the README provider overrides table, and refresh the `MINIMAX_API_KEY` description.

## Verification

- `node scripts/utils.test.js` — 81 passed, 0 failed.
- Smoke-tested `scripts/configure.js` with `MINIMAX_API_KEY` set: confirms the provider is emitted with the two updated models and the correct default base URL, and that `MINIMAX_BASE_URL` overrides the base URL (e.g. to the China endpoint).
